### PR TITLE
Removal of master-slave words

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,8 +51,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Openlava Web Interface'

--- a/openlavaweb/cluster/__init__.py
+++ b/openlavaweb/cluster/__init__.py
@@ -26,8 +26,8 @@ class ClusterBase(object):
         raise NotImplementedError
 
     @property
-    def master(self):
-        """Returns the host object of the current master host"""
+    def main(self):
+        """Returns the host object of the current main host"""
         raise NotImplementedError
 
     def hosts(self):
@@ -75,7 +75,7 @@ class ClusterBase(object):
             'cluster_type',
             'admins',
             'name',
-            'master',
+            'main',
             'hosts',
             'problem_hosts',
             'queues',

--- a/openlavaweb/cluster/openlavacluster.py
+++ b/openlavaweb/cluster/openlavacluster.py
@@ -161,8 +161,8 @@ def raise_cluster_exception(code, message):
         44: "Unknown event",
         45: "Bad event format",
         46: "End of file",
-        47: "Master batch daemon internal error",
-        48: "Slave batch daemon internal error",
+        47: "Main batch daemon internal error",
+        48: "Subordinate batch daemon internal error",
         49: "Batch library internal error",
         50: "Failed in an LSF library call",
         51: "System call failed",
@@ -185,7 +185,7 @@ def raise_cluster_exception(code, message):
         68: "Job parameters cannot be changed now; non-repetitive job is running",
         69: "Modified parameters have not been used",
         70: "Job cannot be run more than once",
-        71: "Unknown cluster name or cluster master",
+        71: "Unknown cluster name or cluster main",
         72: "Modified parameters are being used",
         73: "Queue does not have enough per-host job slots",
         74: "Mbatchd could not find the message that SBD mentions about",
@@ -245,7 +245,7 @@ def raise_cluster_exception(code, message):
         128: "You must set LSB_JOB_MEMLIMIT in lsf.conf to modify the memory limit of a running job",
         129: "No error file specified before job dispatch. Error file does not exist, so error file name\
          cannot be changed",
-        130: "The host is locked by master LIM",
+        130: "The host is locked by main LIM",
         131: "Dependent arrays do not have the same size",
     }
     e = ClusterException
@@ -273,8 +273,8 @@ class Cluster(ClusterBase):
         return lslib.ls_getclustername()
 
     @property
-    def master(self):
-        return Host(lslib.ls_getmastername())
+    def main(self):
+        return Host(lslib.ls_getmainname())
 
     def hosts(self):
         """Returns an array of hosts that are part of the cluster"""
@@ -914,8 +914,8 @@ class HostStatus(NumericStatus):
           - Running exclusive job.
         * - 0x200
           - HOST_STAT_LOCKED_MASTER
-          - Locked by Master LIM
-          - Lim locked by master LIM.
+          - Locked by Main LIM
+          - Lim locked by main LIM.
 
     """
     states = {
@@ -974,9 +974,9 @@ class HostStatus(NumericStatus):
             'description': "Running exclusive job.  ",
         },
         0x200: {
-            'friendly': 'Locked by Master LIM',
+            'friendly': 'Locked by Main LIM',
             'name': 'HOST_STAT_LOCKED_MASTER',
-            'description': "Lim locked by master LIM.  ",
+            'description': "Lim locked by main LIM.  ",
         },
     }
 
@@ -1043,8 +1043,8 @@ class JobStatus(NumericStatus):
        * - 0x10000
          - Unknown
          - JOB_STAT_UNKWN
-         - The slave batch daemon (sbatchd) on the host on which the job is processed has lost
-           contact with the master batch daemon (mbatchd).
+         - The subordinate batch daemon (sbatchd) on the host on which the job is processed has lost
+           contact with the main batch daemon (mbatchd).
 
     """
     states = {
@@ -1108,8 +1108,8 @@ class JobStatus(NumericStatus):
         0x10000: {
             'friendly': "Unknown",
             'name': "JOB_STAT_UNKWN",
-            'description': "The slave batch daemon (sbatchd) on the host on which the job is processed has lost \
-            contact with the master batch daemon (mbatchd).",
+            'description': "The subordinate batch daemon (sbatchd) on the host on which the job is processed has lost \
+            contact with the main batch daemon (mbatchd).",
         },
     }
 
@@ -4954,7 +4954,7 @@ class Host(SingleArgMemoized, HostBase):
             >>> from openlavacluster import Host
             >>> host = Host.get_host_list()[0]
             >>> Host.get_host_list()
-            [master, comp00, comp01, comp02, comp03, comp04]
+            [main, comp00, comp01, comp02, comp03, comp04]
 
         :return: List of :py:class:`cluster.openlavacluster.Host` Objects, one for each host on the cluster.
         :rtype: list
@@ -4994,7 +4994,7 @@ class Host(SingleArgMemoized, HostBase):
             >>> host.open()
             Traceback (most recent call last):
               ...
-            cluster.PermissionDeniedError: Unable to open host: master: User permission denied
+            cluster.PermissionDeniedError: Unable to open host: main: User permission denied
 
         :return: 0 on success
         :raises: :py:exc:`cluster.openlavacluster.ClusterException` when host cannot be opened.
@@ -5016,7 +5016,7 @@ class Host(SingleArgMemoized, HostBase):
             >>> host.close()
             Traceback (most recent call last):
               ...
-            cluster.PermissionDeniedError: Unable to close host: master: User permission denied
+            cluster.PermissionDeniedError: Unable to close host: main: User permission denied
 
         :return: 0 on success
         :raises: :py:exc:`cluster.openlavacluster.ClusterException` when host cannot be closed.

--- a/openlavaweb/views.py
+++ b/openlavaweb/views.py
@@ -762,7 +762,7 @@ def get_job_list(request, job_id=0):
                         "email_user": "",
                         "end_time": 0,
                         "error_file_name": "/dev/null",
-                        "execution_cwd": "//master/home/irvined/openlava-web/tests",
+                        "execution_cwd": "//main/home/irvined/openlava-web/tests",
                         "execution_home_directory": "",
                         "execution_hosts": [],
                         "execution_user_id": 1000,
@@ -922,9 +922,9 @@ def get_job_list(request, job_id=0):
                             "type": "JobStatus"
                         },
                         "submission_host": {
-                            "name": "master",
+                            "name": "main",
                             "type": "Host",
-                            "url": "/olweb/olw/hosts/master"
+                            "url": "/olweb/olw/hosts/main"
                         },
                         "submit_home_directory": "/home/irvined",
                         "submit_time": 1414241607,
@@ -991,7 +991,7 @@ def get_job_list(request, job_id=0):
                         "email_user": "",
                         "end_time": 0,
                         "error_file_name": "/dev/null",
-                        "execution_cwd": "//master/home/irvined/openlava-web/tests",
+                        "execution_cwd": "//main/home/irvined/openlava-web/tests",
                         "execution_home_directory": "",
                         "execution_hosts": [],
                         "execution_user_id": 1000,
@@ -1151,9 +1151,9 @@ def get_job_list(request, job_id=0):
                             "type": "JobStatus"
                         },
                         "submission_host": {
-                            "name": "master",
+                            "name": "main",
                             "type": "Host",
-                            "url": "/olweb/olw/hosts/master"
+                            "url": "/olweb/olw/hosts/main"
                         },
                         "submit_home_directory": "/home/irvined",
                         "submit_time": 1414242197,
@@ -1220,7 +1220,7 @@ def get_job_list(request, job_id=0):
                         "email_user": "",
                         "end_time": 0,
                         "error_file_name": "/dev/null",
-                        "execution_cwd": "//master/home/irvined/openlava-web/tests",
+                        "execution_cwd": "//main/home/irvined/openlava-web/tests",
                         "execution_home_directory": "",
                         "execution_hosts": [],
                         "execution_user_id": 1000,
@@ -1387,9 +1387,9 @@ def get_job_list(request, job_id=0):
                             "type": "JobStatus"
                         },
                         "submission_host": {
-                            "name": "master",
+                            "name": "main",
                             "type": "Host",
-                            "url": "/olweb/olw/hosts/master"
+                            "url": "/olweb/olw/hosts/main"
                         },
                         "submit_home_directory": "/home/irvined",
                         "submit_time": 1414243874,


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.